### PR TITLE
hubotに好きなzoi画像を出せるコマンド追加

### DIFF
--- a/scripts/zoi.coffee
+++ b/scripts/zoi.coffee
@@ -66,7 +66,7 @@ zoi = {
         "https://pbs.twimg.com/media/BswuUTPCYAAVX5n.jpg:small"
         "https://pbs.twimg.com/media/BtcSU0xCcAAmz_W.jpg:small"
     ]
-    "おはようございます":[
+    "おはよう":[
         "https://pbs.twimg.com/media/Bs7qd4uCAAAwalT.jpg:small"
         "https://pbs.twimg.com/media/Bts7OpFCcAEkaO4.jpg:small"
     ]


### PR DESCRIPTION
zoiのサイトに付いているキーワード+zoi で好きな画像を出せるようにしました。
例:

```
Hubot> がんばるzoi
Hubot> https://pbs.twimg.com/media/BspWaPYCAAAI6Ui.jpg:small

Hubot> しんちょくだめです zoi
Hubot> https://pbs.twimg.com/media/Bsw1StjCQAA9NQ1.jpg:small

# キーワードが存在しない or 空白の時はランダム
Hubot> おやすみなさいzoi
Hubot> https://pbs.twimg.com/media/BtcSRdRCMAArUCS.jpg:small

Hubot> zoi
Hubot> https://pbs.twimg.com/media/Bsw1StjCQAA9NQ1.jpg:small
```

良さそうならslackbotと入れ替えたい
