### PR TITLE
keyが該当しないときにランダムに画像が選ばれないことが問題の修正

### DIFF
--- a/scripts/zoi.coffee
+++ b/scripts/zoi.coffee
@@ -103,7 +103,7 @@ module.exports = (robot) ->
             msg.send url
         else
             arr = []
-            for key, url of zoi
-                arr.push(url)
+            for key, urls of zoi
+                for url in urls
+                    arr.push(url)
             msg.send arr[Math.floor(Math.random() * arr.length)]
-


### PR DESCRIPTION
元々、「がんばる」や「ごはん」などの対応するkeyが無いときはランダムに画像が読み込まれるつもりでしたが、
1つのkeyに対して複数のurlが存在するときは複数の画像urlがカンマ区切りで表示されてしまうというバグのせいでslackで表示されていませんでした。

適当に2重ループを回して解決することにしました。

これでzoiしまくれるzoi
