### PR TITLE
zoi add {token} {url}と zoi remove {token}を実装した

### DIFF
--- a/scripts/zoi.coffee
+++ b/scripts/zoi.coffee
@@ -126,6 +126,7 @@ module.exports = (robot) ->
             return
         if not robot.brain.data['zoi'][key]
             robot.brain.data['zoi'][key] = image_url
+            robot.brain.save()
             msg.reply "#{key} を登録しました！"
 
     robot.hear /^zoi remove (.*?)$/, (msg) ->
@@ -140,6 +141,7 @@ module.exports = (robot) ->
             return
         if robot.brain.data['zoi'][key]
             delete robot.brain.data['zoi'][key]
+            robot.brain.save()
             msg.reply "#{key} の登録を消しました！"
 
 


### PR DESCRIPTION
```
zoi add なにか用 https://pbs.twimg.com/media/BuR0v63CUAA0dQb.jpg
```

で、robot.brain.data['zoi']に {'なにか用': https://pbs.twimg.com/media/BuR0v63CUAA0dQb.jpg} を追加して、

```
zoi remove なにか用
```

でそれを削除する仕組みを実装しました。

```
なにか用zoi
```

と誰かが発言すると、 https://pbs.twimg.com/media/BuR0v63CUAA0dQb.jpg を返します。

```
zoi list
```

でも、標準のzoi listのあとに、追加されたzoi listを返すようにしています。
