### PR TITLE
シャープ付きのurlで画像が展開されなくなったのでシャープを削除

### DIFF
--- a/scripts/zoi.coffee
+++ b/scripts/zoi.coffee
@@ -243,9 +243,7 @@ module.exports = (robot) ->
         msg.reply zoi.keywords().join('\n')
 
     robot.hear /^(.*?)\s*zoi$/i, (msg) ->
-        rand_str = Crypto.createHash('md5').update(Math.random().toString()).digest("hex")[0..4]
-
         zoi = new Zoi(robot.brain)
         word = msg.match[1]
         url = (zoi.find(word) || zoi.random())
-        msg.send url + '#' + rand_str
+        msg.send url


### PR DESCRIPTION
#21 への修正

Slackで#付きのurlから画像が展開されなくなったっぽいので#を削除しました